### PR TITLE
fix: self-heal audio-generated flag on frontend render (QA-40)

### DIFF
--- a/includes/class-audio-player.php
+++ b/includes/class-audio-player.php
@@ -21,6 +21,14 @@ class EchoAds_Audio_Player
             // Only show audio player for posts that have generated audio
             $audio_generated = get_post_meta($post->ID, '_echoads_audio_generated', true);
 
+            // Audio generation is asynchronous: the generated flag is normally set
+            // when an editor clicks "Check Status" in wp-admin. Posts whose audio
+            // was auto-generated on publish never get that click, so self-heal by
+            // polling the backend status here (throttled per post).
+            if (!$audio_generated) {
+                $audio_generated = $this->maybe_mark_audio_generated($post->ID);
+            }
+
             if ($audio_generated) {
                 $audio_player = $this->generate_audio_player($post->ID);
                 // Only append/prepend player if valid audio data was found
@@ -37,6 +45,42 @@ class EchoAds_Audio_Player
         }
 
         return $content;
+    }
+
+    private function maybe_mark_audio_generated($post_id)
+    {
+        $audio_requested = get_post_meta($post_id, '_echoads_audio_requested', true);
+        if (empty($audio_requested)) {
+            return false;
+        }
+
+        $transient_key = 'echoads_status_check_' . $post_id;
+        if (get_transient($transient_key)) {
+            return false;
+        }
+        set_transient($transient_key, 1, 5 * MINUTE_IN_SECONDS);
+
+        $status = EchoAds_Post_Sender::fetch_audio_status($post_id);
+        if ($status === false) {
+            return false;
+        }
+
+        update_post_meta($post_id, '_echoads_audio_status', $status);
+
+        if ($status === 'COMPLETED') {
+            update_post_meta($post_id, '_echoads_audio_generated', current_time('mysql'));
+            delete_transient($transient_key);
+            return true;
+        }
+
+        if ($status === 'FAILED' || $status === 'SKIPPED') {
+            // Terminal states: back off much longer so we don't poll a dead article
+            // on every uncached page view. A regeneration + manual status check in
+            // wp-admin still updates the meta directly, bypassing this throttle.
+            set_transient($transient_key, 1, 6 * HOUR_IN_SECONDS);
+        }
+
+        return false;
     }
 
     public function generate_audio_player($post_id)

--- a/includes/class-post-sender.php
+++ b/includes/class-post-sender.php
@@ -171,7 +171,7 @@ class EchoAds_Post_Sender {
 
         // For regenerate requests, check current status first
         if ( $is_regenerate ) {
-            $current_status = $this->fetch_audio_status( $post_id );
+            $current_status = self::fetch_audio_status( $post_id );
             if ( in_array( $current_status, array( 'PENDING', 'PROCESSING' ), true ) ) {
                 wp_send_json_error( array( 'message' => 'Cannot regenerate while audio is being processed. Current status: ' . $current_status ) );
                 return;
@@ -349,7 +349,7 @@ class EchoAds_Post_Sender {
             return;
         }
 
-        $status_result = $this->fetch_audio_status( $post_id );
+        $status_result = self::fetch_audio_status( $post_id );
 
         if ( $status_result === false ) {
             wp_send_json_error( array( 'message' => 'Failed to fetch audio status' ) );
@@ -370,7 +370,7 @@ class EchoAds_Post_Sender {
         ) );
     }
 
-    private function fetch_audio_status( $post_id ) {
+    public static function fetch_audio_status( $post_id ) {
         $api_key = EchoAds_Settings::get_api_key();
         $endpoint = EchoAds_Settings::get_endpoint();
 


### PR DESCRIPTION
## Problem

[QA-40](https://linear.app/ray-digital/issue/QA-40/generated-audio-does-not-appear-on-frontend-article-page): audio generation completes successfully in wp-admin, but no player appears on the public article page — and no related network request is visible in the browser.

The frontend player only renders when the `_echoads_audio_generated` post meta is set, but that meta was written in exactly **one** place: the manual **"Check Status"** button in wp-admin, and only when the backend returns `COMPLETED`. Generation is asynchronous, so:

- Clicking *Generate* only marks the audio as requested (`PENDING`) — the success toast does not set the gate.
- Audio auto-generated on publish (`transition_post_status` hook) **never** shows a player unless an editor later opens the post editor and manually clicks "Check Status".

The "no network request" observation is expected: audio data is fetched server-side in PHP, and when the gate meta is absent the plugin injects nothing into the page at all.

## Fix

- `class-audio-player.php`: the `the_content` filter now self-heals — when a post has `_echoads_audio_requested` but no `_echoads_audio_generated`, it polls the backend status endpoint and sets the generated flag once the backend reports `COMPLETED`, so the player appears with no manual step. Polling is transient-throttled: at most once per 5 minutes per post, backing off to 6 hours after terminal `FAILED`/`SKIPPED` states.
- `class-post-sender.php`: `fetch_audio_status()` promoted to `public static` so the player reuses the existing status fetch/parse logic instead of duplicating it.

The manual "Check Status" button is unchanged — it writes the same meta directly and bypasses the throttle.

## Note for QA

If the plugin on the QA site was installed from a git clone rather than a release zip, the player still won't render UI: `assets/dist/` (the built React bundle) is gitignored and only ships in release builds — check the JS filter in the Network tab for a 404 on `echoads-audio-player.js`.

## Testing

- Not runtime-tested (no local WP environment); needs a smoke test on the QA site: publish a post with auto-generation enabled, wait for backend TTS to complete, load the article page twice (first uncached view triggers the status poll) and confirm the player appears without touching "Check Status".